### PR TITLE
Print traceback to help in debugging

### DIFF
--- a/emojirades/bot.py
+++ b/emojirades/bot.py
@@ -88,7 +88,8 @@ class EmojiradesBot(object):
         try:
             self._handle_event(**payload)
         except Exception as e:
-            traceback.print_exc()
+            if logging.root.level == logging.DEBUG:
+                traceback.print_exc()
             raise e
 
     def _handle_event(self, **payload):

--- a/emojirades/bot.py
+++ b/emojirades/bot.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import os
+import traceback
 
 from emojirades.commands.registry import CommandRegistry
 from emojirades.slack import SlackClient, slack
@@ -84,6 +85,13 @@ class EmojiradesBot(object):
             raise NotImplementedError(f"Returned channel '{channel}' wasn't decoded")
 
     def handle_event(self, **payload):
+        try:
+            self._handle_event(**payload)
+        except Exception as e:
+            traceback.print_exc()
+            raise e
+
+    def _handle_event(self, **payload):
         commands = CommandRegistry.command_patterns()
 
         event = payload["data"]


### PR DESCRIPTION
This will print errors as stack trace rather than the abstracted error message from slack api.