### PR TITLE
Migrate to the new Slack SDK library (v2 => v3)

### DIFF
--- a/bin/emojirades
+++ b/bin/emojirades
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
-from emojirades.bot import EmojiradesBot
-
 import argparse
 import logging
-import slack
 import sys
+
+import slack_sdk
+
+from emojirades.bot import EmojiradesBot
 
 
 if __name__ == "__main__":
@@ -53,7 +54,7 @@ if __name__ == "__main__":
     bot = EmojiradesBot()
 
     # Register the event callback
-    slack.RTMClient.on(event="message", callback=bot.handle_event)
+    slack_sdk.rtm_v2.RTMClient.on(event="message", callback=bot.handle_event)
 
     # Configure the bot mode
     if args.mode == "init":

--- a/emojirades/persistence/handlers/auth.py
+++ b/emojirades/persistence/handlers/auth.py
@@ -25,7 +25,7 @@ class LocalAuthFileHandler:
         self.auth_uri = auth_uri
 
     def load(self):
-        with open(self.auth_uri, "rt") as auth_file:
+        with open(self.auth_uri, "rt", encoding="utf-8") as auth_file:
             return json.load(auth_file)
 
 

--- a/emojirades/persistence/handlers/workspace.py
+++ b/emojirades/persistence/handlers/workspace.py
@@ -71,7 +71,7 @@ class LocalWorkspaceDirectoryHandler:
             if not entry.suffix == ".json":
                 continue
 
-            with open(entry) as workspace_file:
+            with open(entry, "rt", encoding="utf-8") as workspace_file:
                 yield json.load(workspace_file)
 
 

--- a/emojirades/persistence/orm.py
+++ b/emojirades/persistence/orm.py
@@ -78,7 +78,7 @@ def populate(db_uri, table, data_filename, commit_every=100):
     else:
         raise RuntimeError(f"Unknown table {table}?")
 
-    with open(data_filename) as data_file:
+    with open(data_filename, "rt", encoding="utf-8") as data_file:
         data = json.load(data_file)
 
         for i, row in enumerate(data):

--- a/emojirades/slack/slack_client.py
+++ b/emojirades/slack/slack_client.py
@@ -14,7 +14,9 @@ class SlackClient:
         self.logger = logging.getLogger("EmojiradesBot.slack.SlackClient")
 
         # pylint: disable=no-member
-        self.rtmclient = slack_sdk.rtm_v2.RTMClient(token=self.config["bot_access_token"])
+        self.rtmclient = slack_sdk.rtm_v2.RTMClient(
+            token=self.config["bot_access_token"]
+        )
         self.webclient = slack_sdk.WebClient(
             token=self.config["bot_access_token"], timeout=30
         )

--- a/emojirades/slack/slack_client.py
+++ b/emojirades/slack/slack_client.py
@@ -2,7 +2,7 @@ import logging
 
 from expiringdict import ExpiringDict
 
-import slack
+import slack_sdk
 
 from emojirades.persistence import get_auth_handler
 
@@ -14,8 +14,8 @@ class SlackClient:
         self.logger = logging.getLogger("EmojiradesBot.slack.SlackClient")
 
         # pylint: disable=no-member
-        self.rtmclient = slack.RTMClient(token=self.config["bot_access_token"])
-        self.webclient = slack.WebClient(
+        self.rtmclient = slack_sdk.rtm_v2.RTMClient(token=self.config["bot_access_token"])
+        self.webclient = slack_sdk.WebClient(
             token=self.config["bot_access_token"], timeout=30
         )
         # pylint: enable=no-member

--- a/emojirades/tests/helper.py
+++ b/emojirades/tests/helper.py
@@ -78,8 +78,8 @@ class EmojiradeBotTester(unittest.TestCase):
     def get_xyz(self, xyz):
         return self.gamestate.handler.get_xyz(self.config.channel, xyz)
 
-    @patch("slack.RTMClient", autospec=True)
-    @patch("slack.WebClient", autospec=True)
+    @patch("slack_sdk.rtm_v2.RTMClient", autospec=True)
+    @patch("slack_sdk.WebClient", autospec=True)
     def setUp(self, web_client, rtm_client):
         self.responses = []
         self.reactions = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slackclient~=2.9.3
+slack_sdk~=3.9.1
 requests~=2.26.0
 boto3~=1.18.26
 Unidecode~=1.2.0


### PR DESCRIPTION
This PR updates the bot to use the latest slack_sdk library instead of the old 'slackclient'