### PR TITLE
Renaming the user score method call to the new naming

### DIFF
--- a/emojirades/commands/scorekeeper_commands/minusminus_command.py
+++ b/emojirades/commands/scorekeeper_commands/minusminus_command.py
@@ -20,7 +20,7 @@ class MinusMinusCommand(BaseCommand):
         self.logger.debug("Decrementing user's score: %s", target_user)
         self.scorekeeper.minusminus(self.args["channel"], target_user)
 
-        _, score = self.scorekeeper.position_on_scoreboard(
+        _, score = self.scorekeeper.user_score(
             self.args["channel"], target_user
         )
 

--- a/emojirades/commands/scorekeeper_commands/minusminus_command.py
+++ b/emojirades/commands/scorekeeper_commands/minusminus_command.py
@@ -20,9 +20,7 @@ class MinusMinusCommand(BaseCommand):
         self.logger.debug("Decrementing user's score: %s", target_user)
         self.scorekeeper.minusminus(self.args["channel"], target_user)
 
-        _, score = self.scorekeeper.user_score(
-            self.args["channel"], target_user
-        )
+        _, score = self.scorekeeper.user_score(self.args["channel"], target_user)
 
         yield (
             None,


### PR DESCRIPTION
This was missed in the last refactor