### PR TITLE
Help messages only respond to the user who asked

### DIFF
--- a/emojirades/bot.py
+++ b/emojirades/bot.py
@@ -134,7 +134,10 @@ class EmojiradesBot:
                     if kwargs.get("channel") is None:
                         kwargs["channel"] = channel
 
-                    if func == "chat_postEphemeral" and "user" not in kwargs:
+                    if (
+                        response["func"] == "chat_postEphemeral"
+                        and "user" not in kwargs
+                    ):
                         kwargs["user"] = event.player_id
 
                     func(*args, **kwargs)

--- a/emojirades/bot.py
+++ b/emojirades/bot.py
@@ -134,6 +134,9 @@ class EmojiradesBot:
                     if kwargs.get("channel") is None:
                         kwargs["channel"] = channel
 
+                    if func == "chat_postEphemeral" and "user" not in kwargs:
+                        kwargs["user"] = event.player_id
+
                     func(*args, **kwargs)
 
             session.close()

--- a/emojirades/commands/general_commands/help_command.py
+++ b/emojirades/commands/general_commands/help_command.py
@@ -56,11 +56,12 @@ class HelpCommand(BaseCommand):
 
         game_admins = self.gamestate.get_admins(self.args["channel"])
         admins_names = [self.slack.pretty_name(i) for i in game_admins]
+
         yield (
             None,
             {
                 "func": "chat_postEphemeral",
-                "kwargs": {"text": "Game Admins: " + ", ".join(admins_names)},
+                "kwargs": {"text": f"Game Admins: {', '.join(admins_names)}"},
             },
         )
 

--- a/emojirades/commands/general_commands/help_command.py
+++ b/emojirades/commands/general_commands/help_command.py
@@ -36,7 +36,7 @@ class HelpCommand(BaseCommand):
             None,
             {
                 "func": "chat_postEphemeral",
-                kwargs: {"text": "Available commands are:\n"},
+                "kwargs": {"text": "Available commands are:\n"},
             },
         )
         message = f"```\n{'Example':<{longest_example}} {'Description':<{longest_description}}\n"

--- a/emojirades/commands/general_commands/help_command.py
+++ b/emojirades/commands/general_commands/help_command.py
@@ -52,11 +52,17 @@ class HelpCommand(BaseCommand):
                 message += f"{example:<{longest_example}} {description:<{longest_description}}\n"
 
         message += "```"
-        yield (None, message)
+        yield (None, {"func": "chat_postEphemeral", "kwargs": {"text": message}})
 
         game_admins = self.gamestate.get_admins(self.args["channel"])
         admins_names = [self.slack.pretty_name(i) for i in game_admins]
-        yield (None, "Game Admins: " + ", ".join(admins_names))
+        yield (
+            None,
+            {
+                "func": "chat_postEphemeral",
+                "kwargs": {"text": "Game Admins: " + ", ".join(admins_names)},
+            },
+        )
 
     def __str__(self):
         return "HelpCommand"

--- a/emojirades/commands/general_commands/help_command.py
+++ b/emojirades/commands/general_commands/help_command.py
@@ -32,7 +32,7 @@ class HelpCommand(BaseCommand):
                 if example_length > longest_example:
                     longest_example = example_length
 
-        yield (None, "Available commands are:\n")
+        yield (None, {"func": "chat_postEphemeral", kwargs: {"text": "Available commands are:\n"}})
         message = f"```\n{'Example':<{longest_example}} {'Description':<{longest_description}}\n"
 
         for command in self.commands.values():

--- a/emojirades/commands/general_commands/help_command.py
+++ b/emojirades/commands/general_commands/help_command.py
@@ -32,7 +32,13 @@ class HelpCommand(BaseCommand):
                 if example_length > longest_example:
                     longest_example = example_length
 
-        yield (None, {"func": "chat_postEphemeral", kwargs: {"text": "Available commands are:\n"}})
+        yield (
+            None,
+            {
+                "func": "chat_postEphemeral",
+                kwargs: {"text": "Available commands are:\n"},
+            },
+        )
         message = f"```\n{'Example':<{longest_example}} {'Description':<{longest_description}}\n"
 
         for command in self.commands.values():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def slack_web_api(request, test_data):
             self.config = conf
             self.responses = []
             self.reactions = []
+            self.ephemeral_responses = []
 
     foo = Foo(config)
     setup_mock_web_api_server(foo)

--- a/tests/slack.py
+++ b/tests/slack.py
@@ -124,6 +124,9 @@ class MockHandler(SimpleHTTPRequestHandler):
             "/chat.postMessage": {
                 "ok": True,
             },
+            "/chat.postEphemeral": {
+                "ok": True,
+            },
             "/conversations.open": {
                 "ok": True,
                 "channel": {
@@ -179,6 +182,23 @@ class MockHandler(SimpleHTTPRequestHandler):
                 }
 
             self.test.responses.append((message["channel"], message["text"]))
+        elif self.path == "/chat.postEphemeral":
+            response = responses[self.path]
+
+            try:
+                message = json.loads(data)
+            except json.JSONDecodeError:
+                parsed = urllib.parse.parse_qs(data)
+                message = {
+                    "channel": parsed["channel"][0],
+                    "text": parsed["text"][0],
+                    "user": parsed["user"][0],
+                }
+
+            self.test.ephemeral_responses.append(
+                (message["channel"], message["text"], message["user"])
+            )
+
         elif self.path == "/reactions.add":
             response = responses[self.path]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -303,7 +303,7 @@ class TestBotCommands:
             for example, description in command.examples:
                 assert re.compile(
                     rf"{re.escape(example)}\s+{re.escape(description)}"
-                ).search(slack_web_api.responses[-2][1])
+                ).search(slack_web_api.ephemeral_responses[-2][1])
 
     def test_game_status(self, slack_web_api, bot):
         bot.reset_and_transition_to("waiting")


### PR DESCRIPTION
Make part of the help command return a complex response and ensure ephemeral responses are 'returned to sender'

Fixes #337 