### PR TITLE
Make all CLI args support loading via env vars as well

### DIFF
--- a/bin/emojirades
+++ b/bin/emojirades
@@ -4,6 +4,7 @@ import argparse
 import logging
 import time
 import sys
+import os
 
 from emojirades.bot import EmojiradesBot, configure_parent_logger
 
@@ -18,25 +19,58 @@ if __name__ == "__main__":
 
     # Init Database
     parser_init = subparsers.add_parser("init", help="Init Database")
-    parser_init.add_argument("--db-uri", help="Database URI to init", required=True)
+    parser_init.add_argument(
+        "--db-uri",
+        help="Database URI to init",
+        default=os.environ.get("DATABASE_URI"),
+        required="DATABASE_URI" not in os.environ,
+    )
 
     # Populate Database
     parser_populate = subparsers.add_parser("populate", help="Populate Database")
-    parser_populate.add_argument("--db-uri", help="Database URI", required=True)
+    parser_populate.add_argument(
+        "--db-uri",
+        help="Database URI",
+        default=os.environ.get("DATABASE_URI"),
+        required="DATABASE_URI" not in os.environ,
+    )
     parser_populate.add_argument("--table", help="Name of the table", required=True)
     parser_populate.add_argument("--data-file", help="Filename we'll read from", required=True)
 
     # Single Workspace
     parser_single = subparsers.add_parser("single", help="Single Workspace")
-    parser_single.add_argument("--db-uri", help="Database URI to store state", required=True)
-    parser_single.add_argument("--auth-uri", help="JSON file to store auth config", required=True)
+    parser_single.add_argument(
+        "--db-uri",
+        help="Database URI to store state",
+        default=os.environ.get("DATABASE_URI"),
+        required="DATABASE_URI" not in os.environ,
+    )
+    parser_single.add_argument(
+        "--auth-uri",
+        help="JSON file to store auth config",
+        default=os.environ.get("AUTHENTICATION_URI"),
+        required="AUTHENTICATION_URI" not in os.environ,
+    )
 
     # Multiple Workspaces
     parser_multiple = subparsers.add_parser("multiple", help="Multiple Workspaces")
-    parser_multiple.add_argument("--workspaces-uri", help="URI we persist workspaces to", required=True)
+    parser_multiple.add_argument(
+        "--workspaces-uri",
+        help="URI we persist workspaces to",
+        default=os.environ.get("WORKSPACES_URI"),
+        required="WORKSPACES_URI" not in os.environ,
+    )
     parser_multiple.add_argument("--workspace-id", dest="workspace_ids", action="append", help="Specific workspace IDs")
-    parser_multiple.add_argument("--db-uri", help="Optionally override the workspace db_uri")
-    parser_multiple.add_argument("--onboarding-queue", help="SQS queue containing new workspaces to onboard")
+    parser_multiple.add_argument(
+        "--db-uri",
+        help="Optionally override the workspace db_uri",
+        default=os.environ.get("DATABASE_URI"),
+    )
+    parser_multiple.add_argument(
+        "--onboarding-queue",
+        help="SQS queue containing new workspaces to onboard",
+        default=os.environ.get("ONBOARDING_URI"),
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This is in support for running on k8s and loading secrets via env vars is the ideal way to do it.